### PR TITLE
More MVVM approach

### DIFF
--- a/SourceCodes/02_Applications/TextEncodingConverter.WpfApp/MainWindow.xaml
+++ b/SourceCodes/02_Applications/TextEncodingConverter.WpfApp/MainWindow.xaml
@@ -3,6 +3,20 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Text Encoding Converter">
 
+    <Window.Resources>
+        <DataTemplate x:Key="EncodingLabel">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"></ColumnDefinition>
+                    <ColumnDefinition Width="Auto"></ColumnDefinition>
+                    <ColumnDefinition Width="Auto"></ColumnDefinition>
+                </Grid.ColumnDefinitions>
+                <Label Grid.Column="0" FontSize="12" Foreground="Black" Content="{Binding Path=Name}" />
+                <Label Grid.Column="1" FontSize="12" Foreground="Black" Content="{Binding Path=DisplayName}" Margin="10,0,0,0" />
+                <Label Grid.Column="2" FontSize="12" Foreground="Black" Content="{Binding Path=CodePage}" Margin="10,0,0,0" />
+            </Grid>
+        </DataTemplate>
+    </Window.Resources>
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition />
@@ -34,18 +48,20 @@
                     <Label Content="Output Encoding" />
                 </StackPanel>
 
-                <StackPanel Grid.Column="0" Grid.Row="1">
+                <StackPanel Grid.Column="0" Grid.Row="1" Height="30">
                     <ComboBox x:Name="InputEncoding"
                               ItemsSource="{Binding Encodings}"
                               SelectedValue="{Binding InputEncoding}"
-                              Height="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type StackPanel}}, Path=ActualHeight}" />
+                              Height="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type StackPanel}}, Path=ActualHeight}"
+                              ItemTemplate="{StaticResource ResourceKey=EncodingLabel}" />
                 </StackPanel>
 
                 <StackPanel Grid.Column="1" Grid.Row="1">
                     <ComboBox x:Name="OutputEncoding"
                               ItemsSource="{Binding Encodings}"
                               SelectedValue="{Binding OutputEncoding}"
-                              Height="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type StackPanel}}, Path=ActualHeight}" />
+                              Height="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type StackPanel}}, Path=ActualHeight}"
+                              ItemTemplate="{StaticResource ResourceKey=EncodingLabel}" />
                 </StackPanel>
 
                 <StackPanel Grid.Column="2" Grid.Row="0" Grid.RowSpan="2">

--- a/SourceCodes/02_Applications/TextEncodingConverter.WpfApp/MainWindow.xaml.cs
+++ b/SourceCodes/02_Applications/TextEncodingConverter.WpfApp/MainWindow.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using Aliencube.TextEncodingConverter.Configs.Interfaces;
+using Aliencube.TextEncodingConverter.DataContainers;
 using Aliencube.TextEncodingConverter.Services.Interfaces;
 using Aliencube.TextEncodingConverter.ViewModels;
 using Microsoft.WindowsAPICodePack.Dialogs;
@@ -100,8 +101,8 @@ namespace Aliencube.TextEncodingConverter.WpfApp
                 this._converter.Backup(this.Filenames.Items.Cast<string>());
             }
 
-            var ie = ((string)this.InputEncoding.SelectedValue).Split(new string[] { "|" }, StringSplitOptions.RemoveEmptyEntries)[0].Trim();
-            var oe = ((string)this.OutputEncoding.SelectedValue).Split(new string[] { "|" }, StringSplitOptions.RemoveEmptyEntries)[0].Trim();
+            var ie = ((EncodingInfoDataContainer)this.InputEncoding.SelectedValue).Name;
+            var oe = ((EncodingInfoDataContainer)this.OutputEncoding.SelectedValue).Name;
             var o = this._settings.Converter.OutputPath;
 
             var results = new List<string>();

--- a/SourceCodes/04_Models/TextEncodingConverter.ViewModels/MainWindowViewModel.cs
+++ b/SourceCodes/04_Models/TextEncodingConverter.ViewModels/MainWindowViewModel.cs
@@ -1,4 +1,5 @@
-﻿using Aliencube.TextEncodingConverter.Services.Interfaces;
+﻿using Aliencube.TextEncodingConverter.DataContainers;
+using Aliencube.TextEncodingConverter.Services.Interfaces;
 using Aliencube.TextEncodingConverter.ViewModels.Properties;
 using System;
 using System.Collections.ObjectModel;
@@ -47,22 +48,21 @@ namespace Aliencube.TextEncodingConverter.ViewModels
 
         #region Properties
 
-        private ObservableCollection<string> _encodings;
+        private ObservableCollection<EncodingInfoDataContainer> _encodings;
 
         /// <summary>
         /// Gets or sets the list of encodings.
         /// </summary>
-        public ObservableCollection<string> Encodings
+        public ObservableCollection<EncodingInfoDataContainer> Encodings
         {
             get
             {
                 if (this._encodings == null || !this._encodings.Any())
                 {
                     var encodings = this._converter
-                                        .Encodings
-                                        .Select(p => String.Format("{0} | {1} | {2}", p.Name, p.DisplayName, p.CodePage));
+                                        .Encodings;
 
-                    this._encodings = new ObservableCollection<string>(encodings);
+                    this._encodings = new ObservableCollection<EncodingInfoDataContainer>(encodings);
                 }
                 return this._encodings;
             }
@@ -73,20 +73,16 @@ namespace Aliencube.TextEncodingConverter.ViewModels
             }
         }
 
-        private string _inputEncoding;
+		private EncodingInfoDataContainer _inputEncoding;
 
         /// <summary>
         /// Gets or sets the input encoding.
         /// </summary>
-        public string InputEncoding
+        public EncodingInfoDataContainer InputEncoding
         {
-            get
-            {
-                if (String.IsNullOrWhiteSpace(this._inputEncoding))
-                {
-                    this._inputEncoding = this.Encodings.Single(p => p.StartsWith("ks_c_5601-1987"));
-                }
-                return this._inputEncoding;
+            get {
+                return _inputEncoding ??
+                       (_inputEncoding = Encodings.First(p => p.Name.StartsWith("ks_c_5601-1987")));
             }
             set
             {
@@ -95,20 +91,16 @@ namespace Aliencube.TextEncodingConverter.ViewModels
             }
         }
 
-        private string _outputEncoding;
+        private EncodingInfoDataContainer _outputEncoding;
 
         /// <summary>
         /// Gets or sets the output encoding.
         /// </summary>
-        public string OutputEncoding
+        public EncodingInfoDataContainer OutputEncoding
         {
             get
             {
-                if (String.IsNullOrWhiteSpace(this._outputEncoding))
-                {
-                    this._outputEncoding = this.Encodings.Single(p => p.StartsWith("utf-8"));
-                }
-                return this._outputEncoding;
+                return _outputEncoding ?? (_outputEncoding = Encodings.First(p => p.Name.StartsWith("utf-8")));
             }
             set
             {

--- a/SourceCodes/TextEncodingConverter.jmconfig
+++ b/SourceCodes/TextEncodingConverter.jmconfig
@@ -1,0 +1,1 @@
+﻿<?xml version="1.0" encoding="utf-8"?><Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><DontShowAgainInSolution>false</DontShowAgainInSolution></Configuration>


### PR DESCRIPTION
The beauty of WPF MVVM is that, an object can be directly-but-loosely coupled with UI control. In here, EncodingInfoDataContainer instances are projected to XAML Labels in DataTemplate, so does not need string works (and more design friendly).
