### PR TITLE
Extracted EncodingInfoDataContainerView from MainWindow.

### DIFF
--- a/SourceCodes/02_Applications/TextEncodingConverter.WpfApp/App.xaml
+++ b/SourceCodes/02_Applications/TextEncodingConverter.WpfApp/App.xaml
@@ -1,7 +1,11 @@
 ﻿<Application x:Class="Aliencube.TextEncodingConverter.WpfApp.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-
     <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="EncodingInfoDataContainerView.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/SourceCodes/02_Applications/TextEncodingConverter.WpfApp/EncodingInfoDataContainerView.xaml
+++ b/SourceCodes/02_Applications/TextEncodingConverter.WpfApp/EncodingInfoDataContainerView.xaml
@@ -1,0 +1,29 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:containers="clr-namespace:Aliencube.TextEncodingConverter.DataContainers;assembly=Aliencube.TextEncodingConverter.DataContainers">
+    <DataTemplate DataType="{x:Type containers:EncodingInfoDataContainer}">
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+
+            <StackPanel Grid.Column="0">
+                <Label Content="{Binding Path=Name}"
+                           Width="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type StackPanel}}, Path=ActualWidth}"
+                           />
+            </StackPanel>
+            <StackPanel Grid.Column="1">
+                <Label Content="{Binding Path=DisplayName}"
+                           Width="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type StackPanel}}, Path=ActualWidth}"
+                           />
+            </StackPanel>
+            <StackPanel Grid.Column="2">
+                <Label Content="{Binding Path=CodePage}"
+                           Width="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type StackPanel}}, Path=ActualWidth}"
+                           />
+            </StackPanel>
+        </Grid>
+    </DataTemplate>
+</ResourceDictionary>

--- a/SourceCodes/02_Applications/TextEncodingConverter.WpfApp/MainWindow.xaml
+++ b/SourceCodes/02_Applications/TextEncodingConverter.WpfApp/MainWindow.xaml
@@ -1,36 +1,8 @@
 ﻿<Window x:Class="Aliencube.TextEncodingConverter.WpfApp.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:containers="clr-namespace:Aliencube.TextEncodingConverter.DataContainers;assembly=Aliencube.TextEncodingConverter.DataContainers"
         Title="Text Encoding Converter">
-
-    <Window.Resources>
-        <DataTemplate x:Key="EncodingLabel">
-            <Grid>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="*" />
-                </Grid.ColumnDefinitions>
-
-                <StackPanel Grid.Column="0">
-                    <Label Content="{Binding Path=Name}"
-                           Width="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type StackPanel}}, Path=ActualWidth}"
-                           />
-                </StackPanel>
-                <StackPanel Grid.Column="1">
-                    <Label Content="{Binding Path=DisplayName}"
-                           Width="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type StackPanel}}, Path=ActualWidth}"
-                           />
-                </StackPanel>
-                <StackPanel Grid.Column="2">
-                    <Label Content="{Binding Path=CodePage}"
-                           Width="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type StackPanel}}, Path=ActualWidth}"
-                           />
-                </StackPanel>
-            </Grid>
-        </DataTemplate>
-    </Window.Resources>
-    
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition />
@@ -65,7 +37,6 @@
                 <StackPanel Grid.Column="0" Grid.Row="1" Height="30">
                     <ComboBox x:Name="InputEncoding"
                               ItemsSource="{Binding Encodings}"
-                              ItemTemplate="{StaticResource ResourceKey=EncodingLabel}"
                               SelectedValue="{Binding InputEncoding}"
                               Height="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type StackPanel}}, Path=ActualHeight}"
                               />
@@ -74,7 +45,6 @@
                 <StackPanel Grid.Column="1" Grid.Row="1">
                     <ComboBox x:Name="OutputEncoding"
                               ItemsSource="{Binding Encodings}"
-                              ItemTemplate="{StaticResource ResourceKey=EncodingLabel}"
                               SelectedValue="{Binding OutputEncoding}"
                               Height="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type StackPanel}}, Path=ActualHeight}"
                               />

--- a/SourceCodes/02_Applications/TextEncodingConverter.WpfApp/TextEncodingConverter.WpfApp.csproj
+++ b/SourceCodes/02_Applications/TextEncodingConverter.WpfApp/TextEncodingConverter.WpfApp.csproj
@@ -77,6 +77,10 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Page Include="EncodingInfoDataContainerView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="MainWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>


### PR DESCRIPTION
This PR set the `DataType` property  for `EncodingInfoDataContainer` instead of using the `Key` property, so that the `ItemTemplate` property in  `ComboBox` does not need to be set explicitly. In addition, EncodingInfoDataContainerView has been extracted from MainWindow to classify according to View or ViewModel.

 I was wondering whether @YoungjaeKim will accept this PR as I modified some code made from his commit.
