### PR TITLE
Implementing RelayCommand

### DIFF
--- a/SourceCodes/04_Models/TextEncodingConverter.ViewModels/RelayCommand.cs
+++ b/SourceCodes/04_Models/TextEncodingConverter.ViewModels/RelayCommand.cs
@@ -40,6 +40,10 @@ namespace Aliencube.TextEncodingConverter.ViewModels
             this.OnExecute(parameter);
         }
 
-        public event System.EventHandler CanExecuteChanged;
+        public event EventHandler CanExecuteChanged
+        {
+            add { throw new NotSupportedException(); }
+            remove { throw new NotSupportedException(); }
+        }
     }
 }

--- a/SourceCodes/04_Models/TextEncodingConverter.ViewModels/RelayCommand.cs
+++ b/SourceCodes/04_Models/TextEncodingConverter.ViewModels/RelayCommand.cs
@@ -37,7 +37,7 @@ namespace Aliencube.TextEncodingConverter.ViewModels
 
         public void Execute(object parameter)
         {
-            throw new System.NotImplementedException();
+            this.OnExecute(parameter);
         }
 
         public event System.EventHandler CanExecuteChanged;

--- a/SourceCodes/04_Models/TextEncodingConverter.ViewModels/RelayCommand.cs
+++ b/SourceCodes/04_Models/TextEncodingConverter.ViewModels/RelayCommand.cs
@@ -25,7 +25,7 @@ namespace Aliencube.TextEncodingConverter.ViewModels
             get { return this._onCanExecute; }
         }
 
-        public Action<object> OnExecuted
+        public Action<object> OnExecute
         {
             get { return this._onExecute; }
         }

--- a/SourceCodes/04_Models/TextEncodingConverter.ViewModels/RelayCommand.cs
+++ b/SourceCodes/04_Models/TextEncodingConverter.ViewModels/RelayCommand.cs
@@ -10,6 +10,12 @@ namespace Aliencube.TextEncodingConverter.ViewModels
 
         public RelayCommand(Predicate<object> onCanExecute, Action<object> onExecute)
         {
+            if (onCanExecute == null)
+                throw new ArgumentNullException("onCanExecute");
+
+            if (onExecute == null)
+                throw new ArgumentNullException("onExecute");
+
             this._onCanExecute = onCanExecute;
             this._onExecute = onExecute;
         }

--- a/SourceCodes/04_Models/TextEncodingConverter.ViewModels/RelayCommand.cs
+++ b/SourceCodes/04_Models/TextEncodingConverter.ViewModels/RelayCommand.cs
@@ -6,15 +6,22 @@ namespace Aliencube.TextEncodingConverter.ViewModels
     public class RelayCommand : ICommand
     {
         private readonly Predicate<object> _onCanExecute;
+        private readonly Action<object> _onExecute;
 
         public RelayCommand(Predicate<object> onCanExecute, Action<object> onExecute)
         {
             this._onCanExecute = onCanExecute;
+            this._onExecute = onExecute;
         }
 
         public Predicate<object> OnCanExecute
         {
             get { return this._onCanExecute; }
+        }
+
+        public Action<object> OnExecuted
+        {
+            get { return this._onExecute; }
         }
 
         public bool CanExecute(object parameter)

--- a/SourceCodes/04_Models/TextEncodingConverter.ViewModels/RelayCommand.cs
+++ b/SourceCodes/04_Models/TextEncodingConverter.ViewModels/RelayCommand.cs
@@ -1,0 +1,19 @@
+﻿using System.Windows.Input;
+
+namespace Aliencube.TextEncodingConverter.ViewModels
+{
+    public class RelayCommand : ICommand
+    {
+        public bool CanExecute(object parameter)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void Execute(object parameter)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public event System.EventHandler CanExecuteChanged;
+    }
+}

--- a/SourceCodes/04_Models/TextEncodingConverter.ViewModels/RelayCommand.cs
+++ b/SourceCodes/04_Models/TextEncodingConverter.ViewModels/RelayCommand.cs
@@ -1,9 +1,22 @@
-﻿using System.Windows.Input;
+﻿using System;
+using System.Windows.Input;
 
 namespace Aliencube.TextEncodingConverter.ViewModels
 {
     public class RelayCommand : ICommand
     {
+        private readonly Predicate<object> _onCanExecute;
+
+        public RelayCommand(Predicate<object> onCanExecute, Action<object> onExecute)
+        {
+            this._onCanExecute = onCanExecute;
+        }
+
+        public Predicate<object> OnCanExecute
+        {
+            get { return this._onCanExecute; }
+        }
+
         public bool CanExecute(object parameter)
         {
             throw new System.NotImplementedException();

--- a/SourceCodes/04_Models/TextEncodingConverter.ViewModels/RelayCommand.cs
+++ b/SourceCodes/04_Models/TextEncodingConverter.ViewModels/RelayCommand.cs
@@ -32,7 +32,7 @@ namespace Aliencube.TextEncodingConverter.ViewModels
 
         public bool CanExecute(object parameter)
         {
-            throw new System.NotImplementedException();
+            return this.OnCanExecute(parameter);
         }
 
         public void Execute(object parameter)

--- a/SourceCodes/04_Models/TextEncodingConverter.ViewModels/TextEncodingConverter.ViewModels.csproj
+++ b/SourceCodes/04_Models/TextEncodingConverter.ViewModels/TextEncodingConverter.ViewModels.csproj
@@ -54,6 +54,7 @@
     <Compile Include="MainWindowViewModel.cs" />
     <Compile Include="Properties\Annotations.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RelayCommand.cs" />
     <Compile Include="ViewModelServiceLocator.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/SourceCodes/TextEncodingConverter.ViewModels.Tests/Properties/AssemblyInfo.cs
+++ b/SourceCodes/TextEncodingConverter.ViewModels.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("TextEncodingConverter.ViewModels.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("TextEncodingConverter.ViewModels.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2014")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("8c0ed31b-e560-4d98-a44b-052a86a95cd0")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/SourceCodes/TextEncodingConverter.ViewModels.Tests/RelayCommandTest.cs
+++ b/SourceCodes/TextEncodingConverter.ViewModels.Tests/RelayCommandTest.cs
@@ -84,5 +84,19 @@ namespace TextEncodingConverter.ViewModels.Tests
 
             Assert.IsTrue(verified, "Verified...");
         }
+
+        [Test]
+        public void CanExecuteChangedThrowsWhenSubscribed()
+        {
+            var sut = new RelayCommand(x => false, x => { });
+            Assert.Throws<NotSupportedException>(() => sut.CanExecuteChanged += null);
+        }
+
+        [Test]
+        public void CanExecuteChangedThrowsWhenUnsubscribed()
+        {
+            var sut = new RelayCommand(x => false, x => { });
+            Assert.Throws<NotSupportedException>(() => sut.CanExecuteChanged -= null);
+        }
     }
 }

--- a/SourceCodes/TextEncodingConverter.ViewModels.Tests/RelayCommandTest.cs
+++ b/SourceCodes/TextEncodingConverter.ViewModels.Tests/RelayCommandTest.cs
@@ -22,7 +22,7 @@ namespace TextEncodingConverter.ViewModels.Tests
         }
 
         [Test]
-        public void InitializeWithNullOnExecutedThrows()
+        public void InitializeWithNullOnExecuteThrows()
         {
             Assert.Throws<ArgumentNullException>(() => new RelayCommand(x => false, null));
         }
@@ -39,14 +39,14 @@ namespace TextEncodingConverter.ViewModels.Tests
         }
 
         [Test]
-        public void OnExecutedIsCorrect()
+        public void OnExecuteIsCorrect()
         {
-            Action<object> onExecuted = x => { };
-            var sut = new RelayCommand(x => false, onExecuted);
+            Action<object> onExecute = x => { };
+            var sut = new RelayCommand(x => false, onExecute);
 
-            var actual = sut.OnExecuted;
+            var actual = sut.OnExecute;
 
-            Assert.AreEqual(onExecuted, actual);
+            Assert.AreEqual(onExecute, actual);
         }
 
         [Test]

--- a/SourceCodes/TextEncodingConverter.ViewModels.Tests/RelayCommandTest.cs
+++ b/SourceCodes/TextEncodingConverter.ViewModels.Tests/RelayCommandTest.cs
@@ -1,0 +1,17 @@
+﻿using System.Windows.Input;
+using Aliencube.TextEncodingConverter.ViewModels;
+using NUnit.Framework;
+
+namespace TextEncodingConverter.ViewModels.Tests
+{
+    [TestFixture]
+    public class RelayCommandTest
+    {
+        [Test]
+        public void SutIsCommand()
+        {
+            var sut = new RelayCommand();
+            Assert.IsInstanceOf<ICommand>(sut);
+        }
+    }
+}

--- a/SourceCodes/TextEncodingConverter.ViewModels.Tests/RelayCommandTest.cs
+++ b/SourceCodes/TextEncodingConverter.ViewModels.Tests/RelayCommandTest.cs
@@ -66,5 +66,23 @@ namespace TextEncodingConverter.ViewModels.Tests
 
             Assert.AreEqual(expected, actual);
         }
+
+        [Test]
+        public void ExecuteCallsOnExecute()
+        {
+            var parameter = new object();
+            var verified = false;
+            Action<object> onExecute =
+                x =>
+                {
+                    Assert.AreEqual(parameter, x);
+                    verified = true;
+                };
+            var sut = new RelayCommand(x => false, onExecute);
+
+            sut.Execute(parameter);
+
+            Assert.IsTrue(verified, "Verified...");
+        }
     }
 }

--- a/SourceCodes/TextEncodingConverter.ViewModels.Tests/RelayCommandTest.cs
+++ b/SourceCodes/TextEncodingConverter.ViewModels.Tests/RelayCommandTest.cs
@@ -48,5 +48,23 @@ namespace TextEncodingConverter.ViewModels.Tests
 
             Assert.AreEqual(onExecuted, actual);
         }
+
+        [Test]
+        public void CanExecuteCallsOnCanExecute()
+        {
+            var parameter = new object();
+            var expected = true;
+            Predicate<object> onCanExecute =
+                x =>
+                {
+                    Assert.AreEqual(parameter, x);
+                    return expected;
+                };
+            var sut = new RelayCommand(onCanExecute, x => { });
+
+            var actual = sut.CanExecute(parameter);
+
+            Assert.AreEqual(expected, actual);
+        }
     }
 }

--- a/SourceCodes/TextEncodingConverter.ViewModels.Tests/RelayCommandTest.cs
+++ b/SourceCodes/TextEncodingConverter.ViewModels.Tests/RelayCommandTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows.Input;
+﻿using System;
+using System.Windows.Input;
 using Aliencube.TextEncodingConverter.ViewModels;
 using NUnit.Framework;
 
@@ -10,8 +11,19 @@ namespace TextEncodingConverter.ViewModels.Tests
         [Test]
         public void SutIsCommand()
         {
-            var sut = new RelayCommand();
+            var sut = new RelayCommand(null, null);
             Assert.IsInstanceOf<ICommand>(sut);
+        }
+
+        [Test]
+        public void OnCanExecuteIsCorrect()
+        {
+            Predicate<object> onCanExecute = x => false;
+            var sut = new RelayCommand(onCanExecute, null);
+
+            var actual = sut.OnCanExecute;
+
+            Assert.AreEqual(onCanExecute, actual);
         }
     }
 }

--- a/SourceCodes/TextEncodingConverter.ViewModels.Tests/RelayCommandTest.cs
+++ b/SourceCodes/TextEncodingConverter.ViewModels.Tests/RelayCommandTest.cs
@@ -25,5 +25,16 @@ namespace TextEncodingConverter.ViewModels.Tests
 
             Assert.AreEqual(onCanExecute, actual);
         }
+
+        [Test]
+        public void OnExecutedIsCorrect()
+        {
+            Action<object> onExecuted = x => { };
+            var sut = new RelayCommand(null, onExecuted);
+
+            var actual = sut.OnExecuted;
+
+            Assert.AreEqual(onExecuted, actual);
+        }
     }
 }

--- a/SourceCodes/TextEncodingConverter.ViewModels.Tests/RelayCommandTest.cs
+++ b/SourceCodes/TextEncodingConverter.ViewModels.Tests/RelayCommandTest.cs
@@ -11,15 +11,27 @@ namespace TextEncodingConverter.ViewModels.Tests
         [Test]
         public void SutIsCommand()
         {
-            var sut = new RelayCommand(null, null);
+            var sut = new RelayCommand(x => false, x => { });
             Assert.IsInstanceOf<ICommand>(sut);
+        }
+
+        [Test]
+        public void InitializeWithNullOnCanExecuteThrows()
+        {
+            Assert.Throws<ArgumentNullException>(() => new RelayCommand(null, x => { }));
+        }
+
+        [Test]
+        public void InitializeWithNullOnExecutedThrows()
+        {
+            Assert.Throws<ArgumentNullException>(() => new RelayCommand(x => false, null));
         }
 
         [Test]
         public void OnCanExecuteIsCorrect()
         {
             Predicate<object> onCanExecute = x => false;
-            var sut = new RelayCommand(onCanExecute, null);
+            var sut = new RelayCommand(onCanExecute, x => { });
 
             var actual = sut.OnCanExecute;
 
@@ -30,7 +42,7 @@ namespace TextEncodingConverter.ViewModels.Tests
         public void OnExecutedIsCorrect()
         {
             Action<object> onExecuted = x => { };
-            var sut = new RelayCommand(null, onExecuted);
+            var sut = new RelayCommand(x => false, onExecuted);
 
             var actual = sut.OnExecuted;
 

--- a/SourceCodes/TextEncodingConverter.ViewModels.Tests/TextEncodingConverter.ViewModels.Tests.csproj
+++ b/SourceCodes/TextEncodingConverter.ViewModels.Tests/TextEncodingConverter.ViewModels.Tests.csproj
@@ -46,9 +46,16 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RelayCommandTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\04_Models\TextEncodingConverter.ViewModels\TextEncodingConverter.ViewModels.csproj">
+      <Project>{FE60181D-51A2-428A-BE4B-0F5B8C0E8CC6}</Project>
+      <Name>TextEncodingConverter.ViewModels</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/SourceCodes/TextEncodingConverter.ViewModels.Tests/TextEncodingConverter.ViewModels.Tests.csproj
+++ b/SourceCodes/TextEncodingConverter.ViewModels.Tests/TextEncodingConverter.ViewModels.Tests.csproj
@@ -1,0 +1,61 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{9D3B0E59-D64A-4BF0-8826-EF5340CE2ECE}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>TextEncodingConverter.ViewModels.Tests</RootNamespace>
+    <AssemblyName>TextEncodingConverter.ViewModels.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="nunit.framework">
+      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/SourceCodes/TextEncodingConverter.ViewModels.Tests/packages.config
+++ b/SourceCodes/TextEncodingConverter.ViewModels.Tests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="2.6.3" targetFramework="net40" />
+</packages>

--- a/SourceCodes/TextEncodingConverter.sln
+++ b/SourceCodes/TextEncodingConverter.sln
@@ -1,6 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 2013
+VisualStudioVersion = 12.0.30723.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{EC6BF3D6-4534-4DCE-8A8B-5FC81B402B45}"
 	ProjectSection(SolutionItems) = preProject
 		.nuget\packages.config = .nuget\packages.config
@@ -37,6 +39,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TextEncodingConverter.DataC
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TextEncodingConverter.ViewModels", "04_Models\TextEncodingConverter.ViewModels\TextEncodingConverter.ViewModels.csproj", "{FE60181D-51A2-428A-BE4B-0F5B8C0E8CC6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TextEncodingConverter.ViewModels.Tests", "TextEncodingConverter.ViewModels.Tests\TextEncodingConverter.ViewModels.Tests.csproj", "{9D3B0E59-D64A-4BF0-8826-EF5340CE2ECE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -71,18 +75,23 @@ Global
 		{FE60181D-51A2-428A-BE4B-0F5B8C0E8CC6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FE60181D-51A2-428A-BE4B-0F5B8C0E8CC6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FE60181D-51A2-428A-BE4B-0F5B8C0E8CC6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9D3B0E59-D64A-4BF0-8826-EF5340CE2ECE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9D3B0E59-D64A-4BF0-8826-EF5340CE2ECE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9D3B0E59-D64A-4BF0-8826-EF5340CE2ECE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9D3B0E59-D64A-4BF0-8826-EF5340CE2ECE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{02CCF294-E55B-4FF6-8402-A1E1E56CD809} = {7107BFDE-62E8-4C7C-AD25-E1646A0E4691}
+		{DD4770F4-892A-47BE-9DA0-64317BC8403D} = {164F2C3F-995F-41E7-955B-F3F726F41866}
 		{4B06B8A0-AF4B-4FCD-8714-1E7A29E268F6} = {2668A0D5-12AF-4830-8E52-9608EA685CF8}
 		{25E2106F-3650-4F1F-8527-4F1B2185062B} = {E54026DC-DC7E-43F3-BB00-CABD91BFA742}
 		{3EA936C2-A0DC-4BA3-950C-ACB710F605E0} = {E54026DC-DC7E-43F3-BB00-CABD91BFA742}
 		{504D271C-C7BA-4A67-BE78-85814D5ED333} = {81A44B9F-5971-4ECE-A9E6-44F6257B0736}
 		{D7D65EA6-77FF-4204-B7E9-0566B508A43B} = {6652A5F3-C444-483D-9080-B30905511309}
 		{FE60181D-51A2-428A-BE4B-0F5B8C0E8CC6} = {6652A5F3-C444-483D-9080-B30905511309}
-		{DD4770F4-892A-47BE-9DA0-64317BC8403D} = {164F2C3F-995F-41E7-955B-F3F726F41866}
+		{9D3B0E59-D64A-4BF0-8826-EF5340CE2ECE} = {164F2C3F-995F-41E7-955B-F3F726F41866}
 	EndGlobalSection
 EndGlobal

--- a/SourceCodes/TextEncodingConverter.sln.DotSettings
+++ b/SourceCodes/TextEncodingConverter.sln.DotSettings
@@ -13,4 +13,5 @@
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ALIGN_MULTLINE_TYPE_PARAMETER_LIST/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INDENT_ANONYMOUS_METHOD_BLOCK/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/LINE_FEED_AT_FILE_END/@EntryValue">True</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
This PR  implemented the RelayCommand class, which is widely used to represent unrouted(direct) command implementation of the ICommand interface and as you may know, the counterpart of it is the RoutedCommand class.

The command will be used to extract behaviors of views(eg. [Convert_Click](https://github.com/aliencube/Text-Encoding-Converter/blob/master/SourceCodes/02_Applications/TextEncodingConverter.WpfApp/MainWindow.xaml.cs#L92)) as @Jaewoo Ahn mentioned on [FB](https://www.facebook.com/groups/AspxKorea/permalink/746411725453059/?comment_id=746753728752192). I think that you can find many examples with just typing RelayCommand on search engines, but it is [a good example](https://github.com/Code52/MarkPadRT/blame/master/src/MarkPad/ViewModel/MainViewModel.cs#L41-L61) that implemented by @YoungjaeKim, which I just have found.
